### PR TITLE
fix wrong base url when base tag exists

### DIFF
--- a/web-extension/extractHtml.js
+++ b/web-extension/extractHtml.js
@@ -453,7 +453,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         result = {
             url: getPageUrl(tmpTitle),
             title: tmpTitle,
-            baseUrl: getCurrentUrl(),
             styleFileContent: styleFile,
             styleFileName: 'style' + generateRandomNumber() + '.css',
             images: extractedImages,

--- a/web-extension/utils.js
+++ b/web-extension/utils.js
@@ -99,7 +99,11 @@ function setIsBusy(isBusy) {
 }
 
 /////
-function getCurrentUrl() {
+function getBaseUrl() {
+	const base = document.querySelector("base");
+	if (base) {
+		return base.getAttribute("href");
+	}
     let url = window.location.href;
     if (url.indexOf('?') > 0) {
         url = window.location.href.split('?')[0];
@@ -171,7 +175,7 @@ function getAbsoluteUrl(urlStr) {
     }
     try {
         urlStr = decodeHtmlEntity(urlStr);    
-        let currentUrl = getCurrentUrl();
+        let currentUrl = getBaseUrl();
         let originUrl = getOriginUrl();
         let absoluteUrl = urlStr;
 


### PR DESCRIPTION
When base tag https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base exists, relative urls (i.e. images) are not calculated correctly. For instance try to export the angularJS guide:

https://docs.angularjs.org/guide/databinding

This PR fixes the issue by including a check for the base tag, renaming the function getCurrentUrl in the more appropriate getBaseUrl and removing the relative field from the response object in extractHtml, since it's unused. 